### PR TITLE
FortiRecon ACI API endpoint change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # connector-fortinet-fortirecon-aci
+
+## Changelog
+
+### 2.1.1
+
+Edit: <anonyges@gmail.com>
+
+#### Code Changes
+
+- API endpoint change
+  - reports.py, get_reports, endpoint was changed to "/aci/{org_id}/intel/reports"
+  - reports.py, get_reports_with_iocs, endpoint was changed to "/aci/{org_id}/intel/reports"
+  - ioc.py, get_iocs, endpoint was changed to "/aci/{org_id}/intel/iocs"
+  - reference: <https://fndn.fortinet.net/index.php?/fortiapi/2232-fortirecon/5042/2232/ACI/>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
 # connector-fortinet-fortirecon-aci
 
-## Changelog
 
-### 2.1.1
-
-Edit: <anonyges@gmail.com>
-
-#### Code Changes
-
-- API endpoint change
-  - reports.py, get_reports, endpoint was changed to "/aci/{org_id}/intel/reports"
-  - reports.py, get_reports_with_iocs, endpoint was changed to "/aci/{org_id}/intel/reports"
-  - ioc.py, get_iocs, endpoint was changed to "/aci/{org_id}/intel/iocs"
-  - reference: <https://fndn.fortinet.net/index.php?/fortiapi/2232-fortirecon/5042/2232/ACI/>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 # connector-fortinet-fortirecon-aci
-
-

--- a/fortinet-fortirecon-aci/aci_operations/iocs.py
+++ b/fortinet-fortirecon-aci/aci_operations/iocs.py
@@ -10,7 +10,7 @@ from ..make_rest_api_call import MakeRestApiCall
 
 def get_iocs(config: dict, params: dict) -> dict:
     MK = MakeRestApiCall(config=config)
-    endpoint = "/aci/{org_id}/iocs"
+    endpoint = "/aci/{org_id}/intel/iocs"
     if 'report_id' in params:
         params["report_id"] = str(params["report_id"]).strip('[]')
     for date_param in ("start_date", "end_date"):

--- a/fortinet-fortirecon-aci/aci_operations/reports.py
+++ b/fortinet-fortirecon-aci/aci_operations/reports.py
@@ -11,7 +11,7 @@ from ..make_rest_api_call import MakeRestApiCall
 def get_reports(config: dict, params: dict) -> dict:
 
     MK = MakeRestApiCall(config=config)
-    endpoint = "/aci/{org_id}/reports"
+    endpoint = "/aci/{org_id}/intel/reports"
     method = "GET"
 
     if params.get("start_date"):
@@ -26,7 +26,7 @@ def get_reports(config: dict, params: dict) -> dict:
 def get_reports_with_iocs(config: dict, params: dict) -> dict:
 
     MK = MakeRestApiCall(config=config)
-    endpoint = "/aci/{org_id}/reports"+"/{0}".format(params.pop("id"))
+    endpoint = "/aci/{org_id}/intel/reports"+"/{0}".format(params.pop("id"))
     method = "GET"
 
     if params.get("start_date"):

--- a/fortinet-fortirecon-aci/info.json
+++ b/fortinet-fortirecon-aci/info.json
@@ -1,7 +1,7 @@
 {
   "name": "fortinet-fortirecon-aci",
   "label": "Fortinet FortiRecon ACI",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "FortiRecon is a Digital Risk Protection Service (DRPS) product that provides an outside-the-network view to the risks posed to your enterprise.The Adversary Centric Intelligence (ACI) module leverages FortiGuard Threat Analysts to provide comprehensive coverage of dark web, open source, and technical threat intelligence, including threat actor insights. This information enables administrators to proactively assess risks, respond faster to incidents, better understand their attackers, and protect assets. This connector facilitates the automated operations related to ACI. <br/><br/>This connector has a dependency on the <a href=\"/content-hub/all-content/?contentType=solutionpack&amp;tag=ThreatIntelManagement\" target=\"_blank\" rel=\"noopener\">Threat Intel Management Solution Pack</a>. Install the Solution Pack before enabling ingestion of Threat Feeds from this source.",
   "publisher": "Fortinet",
   "contributor": "Ramkrushna Pathade",

--- a/fortinet-fortirecon-aci/playbooks/playbooks.json
+++ b/fortinet-fortirecon-aci/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - Fortinet FortiRecon ACI - 2.0.0",
+      "name": "Sample - Fortinet FortiRecon ACI - 2.1.1",
       "description": "FortiRecon is a Digital Risk Protection Service (DRPS) product that provides an outside-the-network view to the risks posed to your enterprise.The Adversary Centric Intelligence (ACI) module leverages FortiGuard Threat Analysts to provide comprehensive coverage of dark web, open source, and technical threat intelligence, including threat actor insights. This information enables administrators to proactively assess risks, respond faster to incidents, better understand their attackers, and protect assets. This connector facilitates the automated operations related to ACI",
       "visible": true,
       "image": null,
@@ -13,7 +13,8 @@
       "importedBy": [],
       "recordTags": [
         "Fortinet",
-        "fortinet-fortirecon-aci"
+        "fortinet-fortirecon-aci",
+        "dataingestion"
       ],
       "workflows": [
         {

--- a/fortinet-fortirecon-aci/release_notes.md
+++ b/fortinet-fortirecon-aci/release_notes.md
@@ -1,7 +1,23 @@
-#### What's New
+# connector-fortinet-fortirecon-aci
 
- - Added following new actions and their playbooks:
-    - Get Adversary Centric Intelligence (ACI) Reports
-    - Get Specific Adversary Centric Intelligence (ACI) Report
-    - Get Intel IOCs
-    - Get Specific Adversary Centric Intelligence (ACI) IOCs
+## Changelog
+
+### 2.1.1
+
+Edit: <anonyges@gmail.com>
+
+#### Code Changes
+
+- API endpoint change
+  - reports.py, get_reports, endpoint was changed to "/aci/{org_id}/intel/reports"
+  - reports.py, get_reports_with_iocs, endpoint was changed to "/aci/{org_id}/intel/reports"
+  - ioc.py, get_iocs, endpoint was changed to "/aci/{org_id}/intel/iocs"
+  - reference: <https://fndn.fortinet.net/index.php?/fortiapi/2232-fortirecon/5042/2232/ACI/>
+
+### 2.1.0
+
+- Added following new actions and their playbooks:
+  - Get Adversary Centric Intelligence (ACI) Reports
+  - Get Specific Adversary Centric Intelligence (ACI) Report
+  - Get Intel IOCs
+  - Get Specific Adversary Centric Intelligence (ACI) IOCs


### PR DESCRIPTION
#### Descriptions:

FortiRecon ACI API endpoint has been changed due to newer version in FortiRecon.
Current FortiRecon ACI data ingestion does not work.

#### Fix:

- API endpoint change
  - reports.py, get_reports, endpoint was changed to "/aci/{org_id}/intel/reports"
  - reports.py, get_reports_with_iocs, endpoint was changed to "/aci/{org_id}/intel/reports"
  - ioc.py, get_iocs, endpoint was changed to "/aci/{org_id}/intel/iocs"
  - reference: <https://fndn.fortinet.net/index.php?/fortiapi/2232-fortirecon/5042/2232/ACI/>

