### PR TITLE
 fix(4): Version 2.1.2 testing issues incorporated

### DIFF
--- a/fortinet-fortirecon-aci/info.json
+++ b/fortinet-fortirecon-aci/info.json
@@ -1424,7 +1424,7 @@
             "recon_score": "",
             "recon_severity": "",
             "year": "",
-            "tags": "",
+            "tags": [],
             "description": "",
             "products": [],
             "vendors": [],
@@ -1480,7 +1480,7 @@
         "published_ts": "",
         "created_ts": "",
         "lookup_priority": "",
-        "nvd_metadata": ""
+        "nvd_metadata": {}
       }
     },
     {
@@ -1551,6 +1551,7 @@
             "recon_severity": {
               "low": "",
               "medium": "",
+              "high": "",
               "critical": ""
             },
             "nvd_severity": {
@@ -1634,6 +1635,7 @@
             "recon_severity": {
               "low": "",
               "medium": "",
+              "high": "",
               "critical": ""
             },
             "nvd_severity": {
@@ -2369,7 +2371,7 @@
         "victim_sectors": [],
         "victim_description": "",
         "victim_parent_org": "",
-        "victim_revenue_in_usd": [],
+        "victim_revenue_in_usd": "",
         "posted_ts": "",
         "updated_ts": "",
         "collection_ts": ""
@@ -2772,7 +2774,8 @@
             "revenue": "",
             "sectors": [],
             "source": "",
-            "updated_date": ""
+            "updated_date": "",
+            "collection_ts": ""
           }
         ],
         "page": "",


### PR DESCRIPTION
#### Descriptions:
Schema mismatch for :

    Action - Get Vulnerability Intelligence CVEs :
    Error - Type mismatch at hits[0].tags expected primitive, got list

    Action - Get Vulnerability Intelligence CVEs By ID :
    Error - Type mismatch at nvd_metadata: expected primitive, got dict

    Action - Get Vulnerability Intelligence vulnerable products
    Error - Missing keys in output schema: hits[0].recon_severity.high

    Action - Get Vulnerability Intelligence vulnerable vendors
    Error - Missing keys in output schema: hits[0].recon_severity.high

    Action - Get Ransomware Victim Details By ID
    Error - Type mismatch at victim_revenue_in_usd: expected list, got str

    Action - Get Potential Ransomware Victims
    Error - Missing keys in output schema: hits[0].collection_ts


#### Fix:
Update schema for all the actions.

